### PR TITLE
Fix for presenting from view controller with custom presentation

### DIFF
--- a/Source/KnowledgeBaseViewController.m
+++ b/Source/KnowledgeBaseViewController.m
@@ -23,10 +23,13 @@
 {
     KUSUserSession *userSession = [Kustomer sharedInstance].userSession;
     NSURL *URL = [NSURL URLWithString:[NSString stringWithFormat:@"https://%@.kustomer.help/", userSession.orgName]];
-    self = [super initWithURL:URL];
-    if (self && UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
-        self.modalPresentationStyle = UIModalPresentationFormSheet;
+
+    if (self = [super initWithURL:URL]) {
+        self.modalPresentationStyle = UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad
+        ? UIModalPresentationFormSheet
+        : UIModalPresentationOverFullScreen;
     }
+    
     return self;
 }
 

--- a/Source/KustomerViewController.m
+++ b/Source/KustomerViewController.m
@@ -21,10 +21,13 @@
 {
     KUSUserSession *userSession = [Kustomer sharedInstance].userSession;
     KUSSessionsViewController *sessionsViewController = [[KUSSessionsViewController alloc] initWithUserSession:userSession];
-    self = [super initWithRootViewController:sessionsViewController];
-    if (self && UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
-        self.modalPresentationStyle = UIModalPresentationFormSheet;
+
+    if (self = [super initWithRootViewController:sessionsViewController]) {
+        self.modalPresentationStyle = UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad
+        ? UIModalPresentationFormSheet
+        : UIModalPresentationOverFullScreen;
     }
+
     return self;
 }
 

--- a/Source/Views/KUSClosedChatView.m
+++ b/Source/Views/KUSClosedChatView.m
@@ -11,8 +11,6 @@
 #import "KUSColor.h"
 #import "KUSLocalization.h"
 
-static const CGFloat kKUSClosedChatViewHeight = 50.0;
-
 @interface KUSClosedChatView ()
 
 @property (nonatomic, strong) UILabel *infoLabel;


### PR DESCRIPTION
Sometimes it's necessary to present Kustomer from view controllers that have themselves been presented with a custom `modalPresentationStyle`; the default `modalPresentationStyle` for iPhone is `fullScreen` which removes the view hierarchy under the presented view controller, which sometimes causes some weird behaviour when dismissing.
This fix sets `modalPresentationStyle` for **KustomerViewController** and **KnowledgeBaseViewController** to `overFullScreen` so that the underlying view hierarchy is untouched.
The only side effect is that you must ensure that Kustomer screens will have a solid background color to avoid showing the underlying view controllers.