### PR TITLE
Show input field when agent reply to the chat in non-Business hours

### DIFF
--- a/Source/ViewControllers/KUSChatViewController.m
+++ b/Source/ViewControllers/KUSChatViewController.m
@@ -538,7 +538,7 @@
         return;
     }
     
-    BOOL wantsClosedView = _chatMessagesDataSource.isChatClosed;
+    BOOL wantsClosedView = _chatMessagesDataSource.isChatClosed && ([_chatMessagesDataSource otherUserIds].count == 0);
     if (wantsClosedView) {
         self.inputBarView.hidden = YES;
         if ([self.inputBarView isFirstResponder]) {


### PR DESCRIPTION
We test the fix with the following scenario

- [x] When non-business hours are enabled and chat temporarily close and an agent sends a message then chat should show input field.
- [x] When the user contact in business hours then the process should work as normal. 