### PR TITLE
Silent a crash in image picker

### DIFF
--- a/Kustomer.podspec
+++ b/Kustomer.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
   s.name = 'Kustomer'
   s.authors = 'Kustomer.com'
   s.summary = 'The iOS SDK for the Kustomer.com mobile client'
-  s.version = '0.1.35'
+  s.version = '0.1.36'
   s.ios.deployment_target = '9.0'
 
   s.homepage = 'https://github.com/kustomer/customer-ios.git'

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.35</string>
+	<string>0.1.36</string>
 	<key>CFBundleVersion</key>
-	<string>0135</string>
+	<string>0136</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/Source/ViewControllers/KUSChatViewController.m
+++ b/Source/ViewControllers/KUSChatViewController.m
@@ -1056,13 +1056,15 @@
 
 - (void)imagePickerController:(UIImagePickerController *)picker didFinishPickingMediaWithInfo:(NSDictionary<NSString *,id> *)info
 {
-    [self dismissViewControllerAnimated:YES completion:nil];
-
-    UIImage *originalImage = [info valueForKey:UIImagePickerControllerOriginalImage];
-    UIImage *editedImage = [info valueForKey:UIImagePickerControllerEditedImage];
-    UIImage *chosenImage = editedImage ?: originalImage;
-
-    [self.inputBarView attachImage:chosenImage];
+    [picker dismissViewControllerAnimated:YES completion:^ {
+        UIImage *originalImage = [info valueForKey:UIImagePickerControllerOriginalImage];
+        UIImage *editedImage = [info valueForKey:UIImagePickerControllerEditedImage];
+        UIImage *chosenImage = editedImage ?: originalImage;
+    
+        if (chosenImage != nil) {
+            [self.inputBarView attachImage:chosenImage];
+        }
+    }];
 }
 
 - (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker


### PR DESCRIPTION
We have encountered many crashes in the our app due to the image picker behaviour. It is unusual and the original implementation was very good so I had only to check against `nil` value

![screenshot 2019-03-07 at 16 00 38](https://user-images.githubusercontent.com/2681868/53965893-52fbae80-40f2-11e9-8e8d-b7ef3973438c.png)

as you can see in the above image the object we are trying to insert is `nil`, I was able to replicate the behaviour in the simulator, below is the stack trace

```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[__NSArrayM insertObject:atIndex:]: object cannot be nil'
*** First throw call stack:
(
	0   CoreFoundation                      0x0000000115a631bb __exceptionPreprocess + 331
	1   libobjc.A.dylib                     0x00000001148da735 objc_exception_throw + 48
	2   CoreFoundation                      0x00000001159af4ec _CFThrowFormattedException + 194
	3   CoreFoundation                      0x000000011598b775 -[__NSArrayM insertObject:atIndex:] + 1269
	4   Kustomer                            0x000000011286c01b -[KUSInputBar attachImage:] + 139
	5   Kustomer                            0x000000011285c1c9 -[KUSChatViewController imagePickerController:didFinishPickingMediaWithInfo:] + 329
	6   UIKitCore                           0x000000011de1c987 -[UIImagePickerController _imagePickerDidCompleteWithInfo:] + 127
	7   UIKitCore                           0x000000011de1c2c6 __60-[UIImagePickerController didSelectMediaWithInfoDictionary:]_block_invoke + 42
	8   libdispatch.dylib                   0x0000000116c8d595 _dispatch_call_block_and_release + 12
	9   libdispatch.dylib                   0x0000000116c8e602 _dispatch_client_callout + 8
	10  libdispatch.dylib                   0x0000000116c9b99a _dispatch_main_queue_callback_4CF + 1541
	11  CoreFoundation                      0x00000001159c83e9 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 9
	12  CoreFoundation                      0x00000001159c2a76 __CFRunLoopRun + 2342
	13  CoreFoundation                      0x00000001159c1e11 CFRunLoopRunSpecific + 625
	14  GraphicsServices                    0x000000011863b1dd GSEventRunModal + 62
	15  UIKitCore                           0x000000011e4fa81d UIApplicationMain + 140
	16  Glover                              0x000000010d773624 main + 68
	17  libdyld.dylib                       0x0000000116d04575 start + 1
	18  ???                                 0x0000000000000001 0x0 + 1
)
``` 

this only happen when the iOS handed us a `nil` image in the `- (void)imagePickerController:(UIImagePickerController *)picker didFinishPickingMediaWithInfo:(NSDictionary<NSString *,id> *)info` delegate function which is leave us in a weird situation (our hands are tightened) but checking the nil value will prevent the crash. 
