### PR TITLE
Releases/0.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for Kustomer iOS SDK
 
+## 0.3.10
+Release Date: 08/26/2020
+
+* Added `[Kustomer setKbDeflectLanguage:]` to allow for overriding of language used when searching in a KB deflect form
+* Bug fix for certain types of KB deflect search strings
+
 ## 0.3.9
 Release Date: 08/14/2020
 

--- a/Kustomer.podspec
+++ b/Kustomer.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
   s.name = 'Kustomer'
   s.authors = 'Kustomer.com'
   s.summary = 'The iOS SDK for the Kustomer.com mobile client'
-  s.version = '0.3.9'
+  s.version = '0.3.10'
   s.ios.deployment_target = '9.0'
 
   s.homepage = 'https://github.com/kustomer/customer-ios.git'

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The Kustomer iOS SDK requires a valid API Key with role `org.tracking`. See [Get
 The preferred installation method is with [CocoaPods](https://cocoapods.org). Add the following to your `Podfile`:
 
 ```ruby
-pod 'Kustomer', :git => 'https://github.com/kustomer/customer-ios.git', :tag => '0.3.9'
+pod 'Kustomer', :git => 'https://github.com/kustomer/customer-ios.git', :tag => '0.3.10'
 ```
 
 #### Carthage
@@ -34,7 +34,7 @@ pod 'Kustomer', :git => 'https://github.com/kustomer/customer-ios.git', :tag => 
 For [Carthage](https://github.com/Carthage/Carthage), add the following to your `Cartfile`:
 
 ```ogdl
-github "kustomer/customer-ios" ~> 0.3.9
+github "kustomer/customer-ios" ~> 0.3.10
 ```
 
 ## Setup

--- a/Source/DataSources/KUSChatMessagesDataSource.m
+++ b/Source/DataSources/KUSChatMessagesDataSource.m
@@ -1200,7 +1200,13 @@ static const NSTimeInterval kKUSTypingEndDelay = 5.0;
 #pragma mark - KB deflect changes
 - (void)searchKbForString:(NSString *)string completion:(void(^)(NSArray * matches))completion
 {
-  NSString *searchKbString = [NSString stringWithFormat:@"/c/v1/kb/deflection/chat?term=%@&pageSize=3", string];
+  NSString *langString = [[KUSLocalization sharedInstance] kbDeflectLanguage];
+  if(langString == nil) {
+    langString = @"en_us";
+  }
+  NSString *encodedString = [string stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+  NSString *searchKbString = [NSString stringWithFormat:@"/c/v1/kb/deflection/chat?term=%@&pageSize=3&lang=%@", encodedString, langString];
+  
   [[Kustomer sharedInstance].userSession.requestManager
    performRequestType:KUSRequestTypeGet
    endpoint:searchKbString

--- a/Source/Helpers/KUSLocalization.h
+++ b/Source/Helpers/KUSLocalization.h
@@ -13,6 +13,7 @@
 
 @property (nonatomic, copy) NSString *table;
 @property (nonatomic, copy) NSString *language;
+@property (nonatomic, copy) NSString *kbDeflectLanguage;
 
 + (instancetype)sharedInstance;
 - (instancetype)init NS_UNAVAILABLE;

--- a/Source/Helpers/KUSLocalization.m
+++ b/Source/Helpers/KUSLocalization.m
@@ -65,6 +65,11 @@
     }
 }
 
+- (void)setKbDeflectLanguage:(NSString *)language
+{
+  _kbDeflectLanguage = language;
+}
+
 - (void)setTable:(NSString *)table
 {
     _table = table;

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.9</string>
+  <string>0.3.10</string
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Source/Kustomer.h
+++ b/Source/Kustomer.h
@@ -40,6 +40,7 @@ static NSString* const kKUSCustomAttributes = @"KUSCustomAttributesKey";
 + (void)printLocalizationKeys;
 + (void)registerLocalizationTableName:(NSString *)table;
 + (void)setLanguage:(NSString *)language;
++ (void)setKbDeflectLanguage:(NSString *)language;
 
 // Returns the current count of unread messages. It might not be immediately available.
 + (NSUInteger)unreadMessageCount;

--- a/Source/Kustomer.m
+++ b/Source/Kustomer.m
@@ -95,6 +95,11 @@ static NSString *kKustomerOrgNameKey = @"orgName";
     [[self sharedInstance] setLanguage:language];
 }
 
++ (void)setKbDeflectLanguage:(NSString *)language
+{
+  [[self sharedInstance] setKbDeflectLanguage:language];
+}
+
 + (void)isChatAvailable:(void (^)(BOOL success, BOOL enabled))block
 {
     [[self sharedInstance] isChatAvailable:block];
@@ -375,6 +380,11 @@ static KUSLogOptions _logOptions = KUSLogOptionInfo | KUSLogOptionErrors;
 - (void)setLanguage:(NSString *)language
 {
     [[KUSLocalization sharedInstance] setLanguage:language];
+}
+
+- (void)setKbDeflectLanguage:(NSString *)language
+{
+  [[KUSLocalization sharedInstance] setKbDeflectLanguage:language];
 }
 
 - (void)isChatAvailable:(void (^)(BOOL success, BOOL enabled))block


### PR DESCRIPTION
# Overview

Added non-english results to KB search. Fixed bug w/ spaces in query. Added kb language override separate from app-wide language.

## Details

To set the KB language to search for, use this before [Kustomer initializeWithAPIKey:@"…"]:

```
[Kustomer setKbDeflectLanguage:@"KB lang/locale code"]; //e.g. pt_br, es, etc. Same as what's used on KB web.
```