### PR TITLE
Add Missing > Character in Info.plist

### DIFF
--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-  <string>0.3.10</string
+	<string>0.3.10</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
# Overview

`Info.plist` was missing a closing `>`  on line 18:
`<string>0.3.10</string`

There was no GitHub issue for this yet.