### PR TITLE
Move xassets to resource_bundles

### DIFF
--- a/Kustomer.podspec
+++ b/Kustomer.podspec
@@ -17,7 +17,10 @@ Pod::Spec.new do |s|
   s.dependency 'TTTAttributedLabel', '~> 2.0.0'
   s.dependency 'NYTPhotoViewer', '~> 2.0.0'
 
-  s.resources = ['Source/**/*.{png,m4a}', 'Source/Strings.bundle', 'Source/*.xcassets']
+  s.resources = ['Source/**/*.{png,m4a}', 'Source/Strings.bundle']
+  s.resource_bundles = {
+    'KustomerResources' => ['Source/*.xcassets']
+  }
   s.source_files = 'Source/**/*.{h,m}'
   s.requires_arc = true
   s.framework = 'UIKit'


### PR DESCRIPTION
# Overview

Xcode New Build System CocoaPods “Copy Pods Resources” has Assets.car in Output Files and conflict with “Copy Bundle Resources”

Similar issues are described here:
https://stackoverflow.com/questions/58928768/xcode-new-build-system-cocoapods-copy-pods-resources-has-assets-car-in-output
and 
https://github.com/CocoaPods/CocoaPods/issues/8431

## Details

Can't compile with following error:
```
Multiple commands produce '/Users/username/Library/Developer/Xcode/DerivedData/ProjectName-fwxntpbwiprqjyepzzrezvezxrcq/Build/Products/Debug-iphonesimulator/ProjectName.app/Assets.car':
1) Target 'TargetName' (project 'ProjectName') has compile command with input '/Users/username/Documents/project/ios/ProjectName/Images.xcassets'
2) That command depends on command in Target 'TargetName' (project 'ProjectName'): script phase “[CP] Copy Pods Resources”
```